### PR TITLE
Add `on_attach` Method to avoid vim notifications on non `tailwindcss-lsp` files.

### DIFF
--- a/lua/tailwindcss-colors/init.lua
+++ b/lua/tailwindcss-colors/init.lua
@@ -157,6 +157,15 @@ function M.update_highlight(bufnr, change_data)
    end, bufnr)
 end
 
+
+-- This function attaches to a buffer, updating highlights on change
+-- It filters for tailwindcss lsp client
+function M.on_attach(client, bufnr)
+   if client.name == "tailwindcss" then
+      M.buf_attach(bufnr)
+   end
+end
+
 -- This function attaches to a buffer, updating highlights on change
 function M.buf_attach(bufnr)
    bufnr = expand_bufnr(bufnr)

--- a/lua/tailwindcss-colors/init.lua
+++ b/lua/tailwindcss-colors/init.lua
@@ -158,15 +158,24 @@ function M.update_highlight(bufnr, change_data)
 end
 
 
--- This function attaches to a buffer, updating highlights on change
--- It filters for tailwindcss lsp client
+
+---This function attaches to a buffer, updating highlights on change
+---It filters for tailwindcss lsp client
+---@param client table A |vim.lsp.client| object
+---@param bufnr number
 function M.on_attach(client, bufnr)
+   if not client then
+    vim.notify_once "tailwindcss-colors: on_attach client tried to attach to a nil client"
+    return
+   end
+
    if client.name == "tailwindcss" then
       M.buf_attach(bufnr)
    end
 end
 
--- This function attaches to a buffer, updating highlights on change
+---This function attaches to a buffer, updating highlights on change
+---@param bufnr number
 function M.buf_attach(bufnr)
    bufnr = expand_bufnr(bufnr)
 
@@ -231,7 +240,8 @@ function M.buf_attach(bufnr)
    })
 end
 
--- Detaches from the buffer
+---Detaches from the buffer
+---@param bufnr number
 function M.buf_detach(bufnr)
    bufnr = expand_bufnr(bufnr)
    -- clear highlights

--- a/lua/tailwindcss-colors/init.lua
+++ b/lua/tailwindcss-colors/init.lua
@@ -157,8 +157,6 @@ function M.update_highlight(bufnr, change_data)
    end, bufnr)
 end
 
-
-
 ---This function attaches to a buffer, updating highlights on change
 ---It filters for tailwindcss lsp client
 ---@param client table A |vim.lsp.client| object


### PR DESCRIPTION
## Add on_attach Method to avoid vim notifications on non tailwindcss-lsp files

### Overview
This pull request introduces a new `on_attach(client, bufnr)` method to the plugin. The primary goal of this update is to integrate Tailwind CSS LSP client, that our `buf_attach` method is only invoked when the Tailwind CSS LSP is attached to a buffer.

### Motivation
Avoids `tailwindcss-colors` notifications on non `tailwindcss-lsp` buffers. I would frequently get the `tailwindcss-colors: current buffer is not attached to tailwindcss lsp client` notification on non `tailwindcss-lsp` filetypes. It got very distracting so I went ahead and updated it to work on my end.

I choose to make it a new method instead of updating the `buf_attach` method for 2 reasons. 
1. Not to introduce breaking changes to the plugin for those who use it.
2. To allow people to configure it more easily with nvim-lsp and mason. Avoiding doing the client check in their config.

I also updated the public facing methods to more closely follow [Lua Documentation Guidlines](https://keplerproject.github.io/luadoc/manual.html)

---

```lua
---This function attaches to a buffer, updating highlights on change
---It filters for tailwindcss lsp client
---@param client table A |vim.lsp.client| object
---@param bufnr number
function M.on_attach(client, bufnr)
   if not client then
    vim.notify_once "tailwindcss-colors: on_attach client tried to attach to a nil client"
    return
   end

   if client.name == "tailwindcss" then
      M.buf_attach(bufnr)
   end
end
